### PR TITLE
update links to point to threat-dragon

### DIFF
--- a/public/pages/contributing.markdown
+++ b/public/pages/contributing.markdown
@@ -10,16 +10,16 @@ nav_order: 8
 ### Contributing
 
 Pull requests, feature requests, bug reports and feedback of any kind are very welcome, please refer to the page for
-[contributors](https://github.com/OWASP/threat-dragon-core/blob/main/CONTRIBUTING.md). 
+[contributors](https://github.com/OWASP/threat-dragon/blob/main/CONTRIBUTING.md). 
 
 We are trying to keep the test coverage relatively high, so please try to update tests in any PRs.
-There are some [developer notes](https://github.com/OWASP/threat-dragon-core/blob/main/dev-notes.md) in the core
-[threat dragon](https://github.com/OWASP/threat-dragon-core) repo to help get started with this project.
+There are some [developer notes](https://github.com/OWASP/threat-dragon/blob/main/dev-notes.md) in the core
+[threat dragon](https://github.com/OWASP/threat-dragon) repo to help get started with this project.
 
 ### Vulnerability disclosure
 
 If you find a vulnerability in this project please let us know ASAP and we will fix it as a priority.
-For secure disclosure, please see the [security policy](https://github.com/OWASP/threat-dragon-core/blob/main/SECURITY.md).
+For secure disclosure, please see the [security policy](https://github.com/OWASP/threat-dragon/blob/main/SECURITY.md).
 
 ### Project leaders
 


### PR DESCRIPTION
Some links still pointed to the old threat-dragon-core repo, these have been changed to point to threat-dragon repo