### PR TITLE
remove links to docs on project page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![OWASP ZAP scan](https://github.com/threatdragon/threatdragon.github.io/actions/workflows/zap_scan.yaml/badge.svg)](https://github.com/threatdragon/threatdragon.github.io/actions/workflows/zap_scan.yaml)
 
 This repo provides the [documentation site](https://threatdragon.github.io)
-for Threat Dragon up to version 1.6.0.
-The latest version 1.6.1 documentation is now on the [OWASP project site][docsv1].
+for Threat Dragon versions up to 1.6.1 and not versions 2.0 onwards.
+The documentation for version 2.x is created from the [Threat Dragon repo][repo].
 
 [Mike Goodwin](https://github.com/mike-goodwin) created Threat Dragon as an open source community project
 that provides an intuitive and accessible way to model threats.
@@ -14,16 +14,18 @@ Threat Dragon is an [OWASP Lab Project](https://owasp.org/www-project-threat-dra
 There is always plenty to do so please contribute your ideas and time if you can.
 
 ## Testing the docs pages
+
 * make sure you have jekyll installed, following the
-[github docs](https://docs.github.com/en/github/working-with-github-pages/testing-your-github-pages-site-locally-with-jekyll)
+    [github docs](https://docs.github.com/en/github/working-with-github-pages/testing-your-github-pages-site-locally-with-jekyll)
 * install with `bundle install`
 * run the site locally with `bundle exec jekyll serve`
 * browse to http://localhost:4000/ to check all is good
 * build the site with `bundle exec jekyll build`
 
 ### Project leaders:
+
 * [Mike Goodwin](mailto:mike.goodwin@owasp.org)
 * [Jon Gadsden](mailto:jon.gadsden@owasp.org)
 * [Leo Reading](mailto:leo.reading@owasp.org)
 
-[docsv1]: https://owasp.org/www-project-threat-dragon/docs-1/
+[repo]: https://github.com/OWASP/threat-dragon/tree/main/docs

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,5 @@
 # Site settings
 # Used to personalize the Threat Dragon site
-# Accessed via {{ site.title }}, {{ site.email }}, and so on, in the HTML files
-# Create custom variable,
-# and they will be accessible in the templates via {{ site.myvariable }}
 
 title: Threat Dragon
 email: jon.gadsden@owasp.org
@@ -22,14 +19,15 @@ search_enabled: false
 
 # Aux links for the upper right navigation
 aux_links:
-  "Try version 2.0 web app":
+  "Try version 2.x web app":
     - "//www.threatdragon.com/#/"
-  "Download version 1.x app":
+  "Download version 2.x app":
     - "//github.com/OWASP/threat-dragon/releases"
   "Source code on GitHub":
     - "//github.com/OWASP/threat-dragon"
   "OWASP project page":
     - "//owasp.org/www-project-threat-dragon"
+
 # Make Aux links open in a new tab
 aux_links_new_tab: true
 

--- a/public/pages/about.markdown
+++ b/public/pages/about.markdown
@@ -3,13 +3,13 @@ layout: page
 title: About
 permalink: /about
 nav_order: 2
+tags: threatdragon
+document: Threat Dragon version 1.6.1
 ---
 
 ## [OWASP](https://www.owasp.org) Threat Dragon
 
-### note that this page is out of date, see the latest version 1.x [documentation][docsv1]
-
-[Threat Dragon](http://owasp.org/www-project-threat-dragon) is a free, open-source, 
+[Threat Dragon][project] is a free, open-source, 
 cross-platform [threat modeling](https://owasp.org/www-community/Threat_Modeling)
 application including system diagramming and a rule engine to auto-generate threats/mitigations.
 [Mike Goodwin](https://github.com/mike-goodwin) created Threat Dragon as an open source community project
@@ -24,7 +24,8 @@ and a different take on Threat Dragon is provided by [Threat Modeling Gamificati
 Threat Dragon supports STRIDE<sup>[1](#footnote1)</sup>, LINDDUN<sup>[2](#footnote2)</sup> and CIA<sup>[3](#footnote3)</sup>.
 
 There is a good overview of [threat modeling and risk assessment](https://owasp.org/www-community/Application_Threat_Modeling)
-from OWASP, and this expands on what the Threat Dragon project aims for: 
+from OWASP, and this expands on what the Threat Dragon project aims for:
+
 * ease of use and accessible
 * designing a data flow diagram
 * suggesting threats
@@ -42,5 +43,5 @@ The application comes in two variants:
 <sup><a name="footnote2">2</a>: Linkability, Identifiability, Non-repudiation, Detectability, Disclosure of information, Unawareness, Non-compliance</sup><br>
 <sup><a name="footnote3">3</a>: Confidentiality, Integrity, Availability</sup><br>
 
-[docsv1]: https://owasp.org/www-project-threat-dragon/docs-1/
+[project]: http://owasp.org/www-project-threat-dragon
 [releases]: https://github.com/OWASP/threat-dragon/releases/tag/v1.6.1

--- a/public/pages/api.markdown
+++ b/public/pages/api.markdown
@@ -3,20 +3,19 @@ layout: page
 title: Application interface
 permalink: /api/
 nav_order: 7
+tags: threatdragon
+document: Threat Dragon version 1.6.1
 ---
 
 ## [OWASP](https://www.owasp.org) Threat Dragon
 
-### note that this page is out of date, see the latest version 1.x [documentation][docsv1]
-
 Future versions of [Threat Dragon](http://owasp.org/www-project-threat-dragon) should provide an 
-application programming interface to support CI/CD pipleines and the like. At present it 
-provides a very minimal application programming interface, but this is being worked on.
+application programming interface to support CI/CD pipleines and the like.
+At present it provides a very minimal application programming interface, but this is being worked on.
 
 Notional ideas for this API are:
+
 * provide pdf output
 * list unmitigated threats
 * list mitigated threats
 * statistics
-
-[docsv1]: https://owasp.org/www-project-threat-dragon/docs-1/

--- a/public/pages/cli.markdown
+++ b/public/pages/cli.markdown
@@ -3,16 +3,17 @@ layout: page
 title: Command line interface
 permalink: /cli/
 nav_order: 8
+tags: threatdragon
+document: Threat Dragon version 1.6.1
 ---
 
 ## [OWASP](https://www.owasp.org) Threat Dragon
-
-### note that this page is out of date, see the latest version 1.x [documentation][docsv1]
 
 Threat Dragon can be run from the command line and there is a command line interface
 which can be used to access some Threat Dragon features.
 
 ### Run Threat Dragon from the command line
+
 With the desktop version of [Threat Dragon](http://owasp.org/www-project-threat-dragon) installed,
 and if the executable is in the environment path, then Threat Dragon can be run from the command line.
 
@@ -29,6 +30,7 @@ AppImage does not need installation, so after downloading version 1.3.1 (for exa
 `./OWASP-Threat-Dragon-1.3.1.AppImage`
 
 ### Threat Dragon command line interface
+
 The command line interface can be used to directly access some of Threat Dragon's functionality.
 
 Ensure that the executable is in the environment path and run this command to get help :
@@ -69,9 +71,7 @@ Options:
   --help         Show help                                             [boolean]
 ```
 
-Verbosity can be increased from the default of 'error':<br>
-`-v` add warnings and info<br>
-`-vv` add verbose and debug<br>
-`-vvv` all levels of logging<br>
-
-[docsv1]: https://owasp.org/www-project-threat-dragon/docs-1/
+Verbosity can be increased from the default of 'error':  
+`-v` add warnings and info  
+`-vv` add verbose and debug  
+`-vvv` all levels of logging  

--- a/public/pages/contributing.markdown
+++ b/public/pages/contributing.markdown
@@ -3,11 +3,11 @@ layout: page
 title: Contributing
 permalink: /contribute/
 nav_order: 11
+tags: threatdragon
+document: Threat Dragon version 1.6.1
 ---
 
 ## [OWASP](https://www.owasp.org) Threat Dragon
-
-### note that this page is out of date, see the latest version 1.x [documentation][docsv1]
 
 ### Contributing
 
@@ -28,5 +28,3 @@ For secure disclosure, please see the [security policy](https://github.com/OWASP
 * [Mike Goodwin](mailto:mike.goodwin@owasp.org)
 * [Jon Gadsden](mailto:jon.gadsden@owasp.org)
 * [Leo Reading](mailto:leo.reading@owasp.org)
-
-[docsv1]: https://owasp.org/www-project-threat-dragon/docs-1/

--- a/public/pages/credits.markdown
+++ b/public/pages/credits.markdown
@@ -3,6 +3,8 @@ layout: page
 title: Credits
 permalink: /credits/
 nav_order: 12
+tags: threatdragon
+document: Threat Dragon version 1.6.1
 ---
 
 <style type="text/css">
@@ -15,8 +17,6 @@ nav_order: 12
 </style>
 
 ## [OWASP](https://www.owasp.org) Threat Dragon
-
-### note that this page is out of date, see the latest version 1.x [documentation][docsv1]
 
 ### Credits
 
@@ -38,5 +38,3 @@ We are very grateful to the talented artist [DЯΣΛMƧVΣЯƧΣ](https://linktr
 DЯΣΛMƧVΣЯƧΣ has allowed use of the [original artwork](https://www.deviantart.com/thelonelyqueen/art/HW-Lil-Baby-Dragon-Lineart-300502156)
 on condition that it used only for 'not for profit' purposes - perfect for our open source project.
 Cupcake has a birthday as well: DЯΣΛMƧVΣЯƧΣ uploaded the original artwork on 7th May 2012.
-
-[docsv1]: https://owasp.org/www-project-threat-dragon/docs-1/

--- a/public/pages/downloads.markdown
+++ b/public/pages/downloads.markdown
@@ -3,13 +3,14 @@ layout: page
 title: Downloads
 permalink: /downloads/
 nav_order: 10
+tags: threatdragon
+document: Threat Dragon version 1.6.1
 ---
 
 ## [OWASP](https://www.owasp.org) Threat Dragon Downloads
 
-### note that this page is out of date, see the latest version 1.x [documentation][docsv1]
-
 ### Install
+
 The desktop and web application versions of Threat Dragon can be downloaded from the
 [OWASP GitHub area](https://github.com/OWASP/threat-dragon/releases),
 with [version 1.6.1][releases] being the latest version.
@@ -19,6 +20,7 @@ or the [web application version](/install-webapp/).
 ### Supplementary materials
 
 #### Demonstrations
+
 A good introduction is provided by Mike Goodwin giving a
 [lightning demo](https://youtu.be/n6JGcZGFq5o) during the OWASP Open Security Summit in June 2020.
 
@@ -31,6 +33,7 @@ Vlad has also provided [Threat Modeling with OWASP Threat Dragon](https://www.yo
 in Ukrainian.
 
 ##### [OWASP Portland Training Day 2021](https://owasp.org/www-revent-portland-training-day/)
+
 The 'Enter the Dragon' demonstration model provides a staged example:
 
 1. [first step](/public/downloads/enter-the-dragon-1.json) is the project creation
@@ -41,6 +44,7 @@ There is an accompanying 'Enter the Dragon' slide deck [in PDF](/public/download
 and Libre Office [OpenDocument Presentation](/public/downloads/enter-the-dragon.odp) formats.
 
 ##### [OWASP Bristol chapter](https://owasp.org/www-chapter-bristol-uk/)
+
 Presentation at the Bristol chapter [meeting November 2019](https://www.meetup.com/OWASP-Bristol/events/261525682/)
 in [OpenDocument Presentation format](/public/downloads/OWASP_threat_dragon.odp)
 
@@ -49,5 +53,4 @@ OpenDocument Presentation format
 [abbreviated version](/public/downloads/OWASP_introduction_threat_modeling_short.odp)
 and [longer version](/public/downloads/OWASP_introduction_threat_modeling.odp).
 
-[docsv1]: https://owasp.org/www-project-threat-dragon/docs-1/
 [releases]: https://github.com/OWASP/threat-dragon/releases/tag/v1.6.1

--- a/public/pages/getting-started.markdown
+++ b/public/pages/getting-started.markdown
@@ -3,6 +3,8 @@ layout: page
 title: Getting started
 permalink: /getting-started/
 nav_order: 4
+tags: threatdragon
+document: Threat Dragon version 1.6.1
 ---
 
 <style type="text/css">
@@ -21,13 +23,13 @@ nav_order: 4
 </style>
 
 ## [OWASP](https://www.owasp.org) Threat Dragon
-Getting started with [Threat Dragon](http://owasp.org/www-project-threat-dragon) models
 
-### note that this page is out of date, see the latest version 1.x [documentation][docsv1]
+Getting started with [Threat Dragon](http://owasp.org/www-project-threat-dragon) models
 
 ## Create a new model
 
 ### If using the Web application
+
 The Threat Dragon web variant stores its threat models in your GitHub repos.
 This is so that the models can stay close to the code they are modelling.
 Future versions will provide a deeper integration so watch this space but for now,
@@ -48,6 +50,7 @@ When you pick a branch you will be taken to the threat model edit page
 where you can enter general information about your model.
 
 ### If using the Desktop application
+
 The Threat Dragon desktop variant stores its threat models on your local filesystem.
 To get started with your threat model start  the applications and from the welcome page
 select on the **plus** area, or pull down menu 'New'. You will then need to save
@@ -57,6 +60,7 @@ You will then be taken straight to the threat model edit page where you
 can enter general information about your model.
 
 ## Threat model edit page
+
 The Title field is mandatory. All the rest are optional, but they provide context for your model.
 This can be useful if someone else has to pick the model up in the future.
 Click on the **Edit** button to start editing the threat model details.
@@ -88,6 +92,7 @@ Congratulations! You have got the basics done. Next step ...
 mapping out your system [in a diagram](/threat-model-diagrams).
 
 ## Loading a demo model
+
 ![Open demo model](/public/images/explore-demo-model.png){: .image-left }
 
 If you are wondering how to start you can load a demonstration threat model.
@@ -101,12 +106,14 @@ These examples will give some ideas on how to get started with your own models.
 ![Open existing model](/public/images/open-model.png)
 
 ### Web application
+
 If you have a repository that already has threat models, you can open them by
 clicking on the **open** area on the Welcome page.
 You will then be able to navigate to a github repository and branch
 and then choose from a list of existing model files.
 
 ### Desktop application
+
 For an existing model file saved on the local file system, open it by clicking on
 the **open** area on the Welcome page.
 You will then be able to navigate to the model file in your local file system and open it.
@@ -114,10 +121,12 @@ You will then be able to navigate to the model file in your local file system an
 The demo model should give you some ideas on how to get started with your own model.
 
 ## Threat model report
+
 From the Threat Model details view you can see a summary report of your model listing the diagrams,
 elements and threats. Towards the bottom right of the page click on the **Report** button.
 
 You can then customise the report to show or hide:
+
 * Out of scope model elements
 * Mitigated threats
 * Threat model diagrams
@@ -125,5 +134,3 @@ You can then customise the report to show or hide:
 On the desktop variant of Threat Dragon you can **Print** the report or **Save** it as a PDF.
 On the web variant, you can **Print** the report and then, on most browsers,
 the print dialog allows you to save the report as a PDF.
-
-[docsv1]: https://owasp.org/www-project-threat-dragon/docs-1/

--- a/public/pages/home.markdown
+++ b/public/pages/home.markdown
@@ -3,6 +3,8 @@ layout: page
 title: Home
 permalink: /home
 nav_order: 1
+tags: threatdragon
+document: Threat Dragon version 1.6.1
 ---
 
 <style type="text/css">
@@ -20,13 +22,9 @@ nav_order: 1
 }
 </style>
 
-[owasp-organization]: https://github.com/owasp
-
 ## [OWASP](https://www.owasp.org) Threat Dragon
 
 ![Cupcake Image](/public/images/threatdragonx256.png){: .image-left }
-
-### note that this page is out of date, see the latest version 1.x [documentation][docsv1]
 
 Threat Dragon is an open-source threat modelling tool from OWASP.
 It is used both as a [web application](/install-webapp/)
@@ -45,5 +43,3 @@ Threat Dragon is an OWASP Lab project but there still might be some bugs - if yo
 [raise a bug report](https://github.com/OWASP/threat-dragon/issues/new?assignees=&labels=bug&template=bug_report.md&title=).
 
 ![OWASP logo](/public/images/owasp.png){: .image-right }
-
-[docsv1]: https://owasp.org/www-project-threat-dragon/docs-1/

--- a/public/pages/install/install-desktop.markdown
+++ b/public/pages/install/install-desktop.markdown
@@ -4,32 +4,34 @@ title: Desktop application install
 parent: Install
 permalink: /install-desktop/
 nav_order: 3
+tags: threatdragon
+document: Threat Dragon version 1.6.1
 ---
 
 ## [OWASP](https://www.owasp.org) Threat Dragon
 
-### note that this page is out of date, see the latest version 1.x [documentation][docsv1]
-
-[Threat Dragon](http://owasp.org/www-project-threat-dragon) comes in two variants, a desktop application and a web application.
+[Threat Dragon][td] comes in two variants, a desktop application and a web application.
 
 ## Desktop application install instructions
-Installers can be downloaded from the [OWASP GitHub area][releases]:
+
+Installers can be downloaded from the [OWASP GitHub area][release]:
 
 * Windows (64 bit) installer
 * MacOS installer
 * Linux snap, AppImage, debian and rpm installers
 
 ### Linux installer and AppImage
-It is probably simpler to use the [AppImage][releases] for most Linux platforms,
+
+It is probably simpler to use the [AppImage][release] for most Linux platforms,
 but packages for both Debian and Fedora Linux on AMD64 and X86-64bit platforms
-can also be downloaded from the [github release area][releases].
+can also be downloaded from the [github release area][release].
 
 Alternatively a platform independent Snap image is available via the
 [official snapcraft distribution](https://snapcraft.io/threat-dragon).
 
 ### MacOS installer
-Download the **.dmg** MacOS installer from the
-[github release area](https://github.com/OWASP/threat-dragon-desktop/releases/).
+
+Download the **.dmg** MacOS installer from the [github release area][release].
 Open the download and drag 'OWASP Threat  Dragon' to the application directory. When the copy has
 finished then Threat Dragon can be run from Apple Launchpad or using Finder -> Applications.
 
@@ -48,7 +50,8 @@ If you decide to use the MacOS **.zip** file then be sure to
 If you run into problems then consider using the **.dmg** download instead.
 
 ### Windows installer
-Download the Windows .exe NSIS installer from the [github release area][releases].
+
+Download the Windows .exe NSIS installer from the [github release area][release].
 Run the installer and invoke the application from the shortcut.
 
 Windows may warn you that this is an application downloaded from the internet and ask you if you want to keep it.
@@ -89,5 +92,5 @@ For example to export a given threat model file to pdf :
 
 `npm run pdf ./threat-model.json`
 
-[docsv1]: https://owasp.org/www-project-threat-dragon/docs-1/
-[releases]: https://github.com/OWASP/threat-dragon/releases/tag/v1.6.1
+[release]: https://github.com/OWASP/threat-dragon/releases/tag/v1.6.1
+[td]: http://owasp.org/www-project-threat-dragon

--- a/public/pages/install/install-webapp.markdown
+++ b/public/pages/install/install-webapp.markdown
@@ -8,14 +8,15 @@ nav_order: 1
 
 ## [OWASP](https://www.owasp.org) Threat Dragon
 
-### note that this page is out of date, see the latest version 1.x [documentation][docsv1]
-
-[Threat Dragon](http://owasp.org/www-project-threat-dragon) comes in two variants, a desktop application and a web application.
+[Threat Dragon](http://owasp.org/www-project-threat-dragon) comes in two variants,
+a desktop application and a web application.
 
 ## Web application install instructions
+
 The web application can be run locally or by using a remote server.
 
 ### Using a Docker container
+
 Pull the Threat Dragon docker image using `docker pull owasp/threat-dragon:stable`.
 The `stable` tag will always be the latest official release, alongside the specific release versions.
 
@@ -27,13 +28,14 @@ The environment variables will need configuration and there is a [step-by-step g
 Once the environment is set up and the docker image is ready, run the docker container using a command such as:
 
 ```
-docker run -it --rm -p 3000:3000 -v $(pwd)/.env:/app/.env owasp/threat-dragon:v1.6.0
+docker run -it --rm -p 3000:3000 -v $(pwd)/.env:/app/.env owasp/threat-dragon:v1.6.1
 ```
 
 assuming:
+
 * use of port 3000, this can be changed to another port for example `-p 3000:5000` for port 5000
 * you are running from the directory  which contains the `.env` file
-* it was version `1.5.8` that was pulled from dockerhub. Replace with later versions as necessary
+* it was version `1.6.1` that was pulled from dockerhub. Replace with later versions as necessary
 
 Note that a valid environment must  be provided, otherwise the container will halt with errors
 such as `Error: GITHUB_CLIENT_ID is a required property`.
@@ -65,21 +67,25 @@ Once you have done that you need to set the Client ID and Client Secret as envir
 (`GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`).
 You also need to set a session signing key environment variable (`SESSION_SIGNING_KEY`).
 
-Once a user is signed in, their session information contains an OAuth access token with write access to their GitHub repos.
+Once a user is signed in, their session information contains an OAuth access token
+with write access to their GitHub repos.
 For security, this is encrypted before storage in the session.
 The session encryption supports multiple keys so that they can be expired
-without any interruption to the running application. The primary key is always used for encryption. Retired keys can be kept available
-for decrypting existing sessions. Once all sessions are using the new primary key (typically this will be around 60 minutes maximum),
+without any interruption to the running application. The primary key is always used for encryption.
+Retired keys can be kept available for decrypting existing sessions.
+Once all sessions are using the new primary key (typically this will be around 60 minutes maximum),
 the old one can be safely removed.
 The keys are stored as a JSON string in  the `SESSION_ENCRYPTION_KEYS` environment variable. For example:
 
 `[{\"isPrimary\": true, \"id\": 0, \"value\": \"abcdef\"}, {\"isPrimary\": false, \"id\": 1, \"value\": \"ghijkl\"}]`
 
-If you are developing locally, you can choose to store the session data in memory using the express-session in-memory store.
+If you are developing locally,
+you can choose to store the session data in memory using the express-session in-memory store.
 To do this set the `SESSION_STORE`environment variable to `local`.
-As [mentioned in the express-session docs](https://github.com/expressjs/session) this is for development only
-- it is not suitable for production. To remind you of this, Threat Dragon will write a log message at severity ERROR when
-it starts if the in memory session store is used.
+As [mentioned in the express-session docs](https://github.com/expressjs/session) this is
+for development only - it is not suitable for production.
+To remind you of this, Threat Dragon will write a log message at severity ERROR when
+it starts if the in-memory session store is used.
 
 By default Threat Dragon will set the `secure` flag on cookies.
 To override this for development purposes set the `NODE_ENV` environment variable to `development`.
@@ -91,5 +97,3 @@ Once your environment variables are set up, start the node web server:
 `npm start`
 
 If you then browse to `http://localhost:3000` you should see the running application.
-
-[docsv1]: https://owasp.org/www-project-threat-dragon/docs-1/

--- a/public/pages/install/install.markdown
+++ b/public/pages/install/install.markdown
@@ -5,20 +5,22 @@ permalink: /install/
 has_children: true
 has_toc: true
 nav_order: 3
+tags: threatdragon
+document: Threat Dragon version 1.6.1
 ---
 
 ## [OWASP](https://www.owasp.org) Threat Dragon
 
-### note that this page is out of date, see the latest version 1.x [documentation][docsv1]
-
 [Threat Dragon][td] comes in two variants, desktop application and web application.
 
 ### Web application
+
 The web application can be run locally or from a server, and is downloaded from the [Threat Dragon repo][releases].
 
 There is some configuration necessary, refer to the [install instructions](/install-webapp/) for configuring the application.
 
 ### Desktop application
+
 Installers can be downloaded from the [OWASP GitHub area][releases]:
 
 * Windows (64 bit) installer
@@ -27,6 +29,5 @@ Installers can be downloaded from the [OWASP GitHub area][releases]:
 
 See the detailed [install instructions](/install-desktop/).
 
-[docsv1]: https://owasp.org/www-project-threat-dragon/docs-1/
 [releases]: https://github.com/OWASP/threat-dragon/releases/tag/v1.6.1
 [td]: http://owasp.org/www-project-threat-dragon

--- a/public/pages/install/setup-env.markdown
+++ b/public/pages/install/setup-env.markdown
@@ -4,15 +4,16 @@ title: Web app environment
 parent: Install
 permalink: /setup-env/
 nav_order: 2
+tags: threatdragon
+document: Threat Dragon version 1.6.1
 ---
 
 ## [OWASP](https://www.owasp.org) Threat Dragon
 
-### note that this page is out of date, see the latest version 1.x [documentation][docsv1]
-
-Setting up the web application environment variables for [Threat Dragon](http://owasp.org/www-project-threat-dragon).
+Setting up the web application environment variables for [Threat Dragon][project].
 
 ## Configuring Environment Variables
+
 Environment variables can be configured by [exporting variables](#using-command-line) to your terminal
 from which you'll be running Threat Dragon, or by using a  `.env` [local file](#using-dotenv).
 
@@ -29,42 +30,48 @@ from which you'll be running Threat Dragon, or by using a  `.env` [local file](#
 * Register the application, an example screenshot [is shown below](#example-oauth-registration).
 
 * In this new OAuth App, note the values for the 20 character long Client ID (used here `01234567890123456789`)
-and the 40 character long Client Secret (used here `0123456789abcdef0123456789abcdef01234567`)
+    and the 40 character long Client Secret (used here `0123456789abcdef0123456789abcdef01234567`)
 
 * Generate a random 32 character hexadecimal key (something like `11223344556677889900aabbccddeeff`)
 
 You now have all the info to set up the environment variables.
 
 ### Using Dotenv
+
 If you are using dotenv then place a file named `.env` at the root of the project with your environment variables.
 An `example.env` is provided as a reference.
 Threat Dragon will then load any variables in this file as environment variables,
 and you do not need to setup the environment variables [from the command line](#using-command-line).
 
 ### Using Command line
+
 If you are not using [dotenv](#using-dotenv), then the environment variables can be set from the command line.
 
 #### MacOS / Linux
-For MacOS and Linux go into the terminal from which you start Threat Dragon and enter at the
-command line:
+
+For MacOS and Linux go into the terminal from which you start Threat Dragon
+and enter at the command line:
+
 * GITHUB_CLIENT_ID from Client ID above,
-for example `export GITHUB_CLIENT_ID=01234567890123456789`
+    for example `export GITHUB_CLIENT_ID=01234567890123456789`
 * GITHUB_CLIENT_SECRET from Client Secret above,
-for example `export GITHUB_CLIENT_SECRET=0123456789abcdef0123456789abcdef01234567`
+    for example `export GITHUB_CLIENT_SECRET=0123456789abcdef0123456789abcdef01234567`
 * `export NODE_ENV=development`
 * `export SESSION_STORE=local`
 * SESSION_SIGNING_KEY as the random 32 character hexadecimal key,
-for example `export SESSION_SIGNING_KEY=11223344556677889900aabbccddeeff`
+    for example `export SESSION_SIGNING_KEY=11223344556677889900aabbccddeeff`
 * SESSION_ENCRYPTION_KEYS has the same 32 character key,
-for example `export SESSION_ENCRYPTION_KEYS='[{"isPrimary": true, "id": 0, "value": "11223344556677889900aabbccddeeff"}]'`
+    for example `export SESSION_ENCRYPTION_KEYS='[{"isPrimary": true, "id": 0, "value": "11223344556677889900aabbccddeeff"}]'`
 * GITHUB_SCOPE - set this to `repo` if you want access also to private repos
 
-Note that we are suing the example values for these variables, and the values obtained in 
+Note that we are using the example values for these variables, and the values obtained in 
 the 'Values for the environment variables' section **must** be used instead.
 
 #### Windows
+
 Similarly for Windows, from the terminal used to start Threat Dragon enter at the
 command line:
+
 * `set GITHUB_CLIENT_ID=01234567890123456789`
 * `set GITHUB_CLIENT_SECRET=0123456789abcdef0123456789abcdef01234567`
 * `set NODE_ENV=development`
@@ -72,16 +79,18 @@ command line:
 * `set SESSION_SIGNING_KEY=11223344556677889900aabbccddeeff`
 * `set SESSION_ENCRYPTION_KEYS='[{"isPrimary": true, "id": 0, "value": "11223344556677889900aabbccddeeff"}]'`
 
-Note that we are suing the example values for these variables, and the values obtained in 
+Note that we are using the example values for these variables, and the values obtained in 
 the 'Values for the environment variables' section **must** be used instead.
 
 ## Check it is running
-You should now be able to start Threat Dragon web application using `npm start`
-and then navigate in a browser to "http://localhost:3000/"
+
+You should now be able to start Threat Dragon web application
+using `npm start` and then navigate in a browser to "http://localhost:3000/"
 
 ### Example OAuth registration
+
 Example screenshot of registering a new OAuth application:
 
 ![Register new OAuth application](/public/images/register-new-OAuth-application.png)
 
-[docsv1]: https://owasp.org/www-project-threat-dragon/docs-1/
+[project]: http://owasp.org/www-project-threat-dragon

--- a/public/pages/threat-generation.markdown
+++ b/public/pages/threat-generation.markdown
@@ -3,15 +3,16 @@ layout: page
 title: Threat generation
 permalink: /threat-generation/
 nav_order: 6
+tags: threatdragon
+document: Threat Dragon version 1.6.1
 ---
 
 ## [OWASP](https://www.owasp.org) Threat Dragon
 
-### note that this page is out of date, see the latest version 1.x [documentation][docsv1]
-
 Threat generation for [Threat Dragon](http://owasp.org/www-project-threat-dragon)
 
 ## Adding and editing single threats
+
 To add threats to elements in your diagram, select an element
 and click on 'Edit Threats' to the left side of the diagram editor.
 This will collapse the model element stencil and show the threats for the selected element.
@@ -23,6 +24,7 @@ When you are done hit **Save** and your new threat should appear.
 To edit it again click on the threat title.
 
 ## STRIDE, LINDDUN and CIA
+
 The threat model can have different types of threats added to it according to your preferred methodology.
 Currently the supported methodologies are STRIDE, LINDDUN and CIA;
 these can be selected using the radio buttons on the diagram.
@@ -44,6 +46,7 @@ elements on the diagram, except for trust boundaries.
 The suggested threats can be individually accepted or ignored, and other threats added manually.
 
 ### Threats by element
+
 According to the type of diagram (STRIDE, LINDDUN and CIA), Threat Dragon can suggest categories
 of threats per element. When editing a STRIDE diagram, selecting '**+** STRIDE per element"
 will suggest threats that are more suitable for the selected element.
@@ -54,6 +57,7 @@ associated with it, and less likely to be vulnerable to
 Tampering, Information disclosure, Denial of service or Elevation of privileges.
 
 ### Threats by context
+
 Threat Dragon can also suggest threats according to the properties for a diagram element.
 These properties are particular for each type of element; for example an Actor element
 has property 'Provides authentication' and a Data Flow element has properties
@@ -63,5 +67,3 @@ When editing a threat model diagram, selecting '**+** Threats within context"
 will suggest threats using the properties for the selected element.
 Many of these suggestions based on the OWASP
 [Automated Threats to Web Applications](https://owasp.org/www-project-automated-threats-to-web-applications/).
-
-[docsv1]: https://owasp.org/www-project-threat-dragon/docs-1/

--- a/public/pages/threat-model-diagrams.markdown
+++ b/public/pages/threat-model-diagrams.markdown
@@ -3,11 +3,11 @@ layout: page
 title: Threat model diagrams
 permalink: /threat-model-diagrams/
 nav_order: 5
+tags: threatdragon
+document: Threat Dragon version 1.6.1
 ---
 
 ## [OWASP](https://www.owasp.org) Threat Dragon
-
-### note that this page is out of date, see the latest version 1.x [documentation][docsv1]
 
 Creating the [Threat Dragon](http://owasp.org/www-project-threat-dragon) diagrams
 
@@ -86,6 +86,7 @@ Processes, data stores, actors and data flows that have open (unmitigated) threa
 ![elements with open threats are red](/public/images/openthreats.png)
 
 ## Editing toolbar
+
 The toolbar on the diagram editing page supports some general diagramming features:
 
 * Toggle gridlines on/off. When gridlines are on, elements snap to them for neater models
@@ -97,9 +98,8 @@ The toolbar on the diagram editing page supports some general diagramming featur
 * Save the threat model to your local browser storage
 
 ## Element properties
+
 To edit the properties of a model element, first select it.
 The element properties are shown on the right side of the diagram editor.
 In a future version of Threat Dragon, these properties will be used by the
 threat generation engine to suggest threats and mitigations for your model.
-
-[docsv1]: https://owasp.org/www-project-threat-dragon/docs-1/

--- a/public/pages/utilities.markdown
+++ b/public/pages/utilities.markdown
@@ -3,11 +3,11 @@ layout: page
 title: Utilities
 permalink: /utils/
 nav_order: 9
+tags: threatdragon
+document: Threat Dragon version 1.6.1
 ---
 
 ## [OWASP](https://www.owasp.org) Threat Dragon
-
-### note that this page is out of date, see the latest version 1.x [documentation][docsv1]
 
 ### Utilities
 
@@ -37,15 +37,16 @@ threat-dragon$ python tmt2td.py
 The [ITMJ project](https://github.com/OWASP/threat-dragon/tree/main/utils/threat-mvp)
 aims to have a greater visibility of the possible threats
 and a better tracking of the actions taken to mitigate them.
+
 - TM data generated automatically within the backlog of each project.
 - Dual sync between Threat Dragon and project management.
 
 #### Prerequisite
+
 - You need to install requests library for python: pip install requests
 - You need to add credentials in config.ini file
 
 #### Run the code
+
 - To run the code: `python3 itmj.py [path threat dragon file] [key project] [epic project]`
 - Example: `python3 itmj.py td_json/test1.json ITMJ ITMJ-2`
-
-[docsv1]: https://owasp.org/www-project-threat-dragon/docs-1/


### PR DESCRIPTION
Reinstates these pages as the main docs pages for version 1.x up to 1.6.1